### PR TITLE
Add product category ABM and remove duplicate section

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,74 +135,44 @@ elif seccion == "📂 Categorías de MP (ABM)":
         conn.commit()
         st.experimental_rerun()
 
-
-# ⚙️ CATEGORÍAS DE PRODUCTOS (ABM)
-elif seccion == "🧪 Producto (ABM)":
-    st.title("🧪 Productos – ABM")
-    categorias_prod = pd.read_sql_query("SELECT * FROM categoria_productos", conn)
-
-    st.subheader("Filtrar y ver productos")
-    if not categorias_prod.empty:
-        cat_sel = st.selectbox("Categoría de productos", categorias_prod["nombre"].tolist(), key="cat_prod_filtro")
-        cat_id = categorias_prod[categorias_prod["nombre"] == cat_sel]["id"].values[0]
-
-        productos_df = pd.read_sql_query("""
-            SELECT p.id, p.nombre, p.margen, cp.nombre AS categoria, sp.nombre AS subcategoria
-            FROM productos p
-            LEFT JOIN categoria_productos cp ON p.categoria_id = cp.id
-            LEFT JOIN subcategorias_productos sp ON p.subcategoria_id = sp.id
-            WHERE p.categoria_id = ?
-        """, conn, params=(cat_id,))
-        st.dataframe(productos_df)
-
-        st.subheader("Editar o eliminar un producto")
-        if not productos_df.empty:
-            prod_dict = dict(zip(productos_df["nombre"], productos_df["id"]))
-            prod_sel = st.selectbox("Seleccioná un producto", list(prod_dict.keys()), key="prod_edit_sel")
-            prod_id = prod_dict[prod_sel]
-            datos = pd.read_sql_query("SELECT * FROM productos WHERE id = ?", conn, params=(prod_id,)).iloc[0]
-
-            new_nombre = st.text_input("Nuevo nombre del producto", value=datos["nombre"], key="prod_edit_nombre")
-            new_margen = st.number_input("Nuevo margen de ganancia", value=datos["margen"], step=0.1, key="prod_edit_margen")
-
-            subcats = pd.read_sql_query("SELECT * FROM subcategorias_productos WHERE categoria_id = ?", conn, params=(datos["categoria_id"],))
-            subcat_dict = dict(zip(subcats["nombre"], subcats["id"]))
-            subcat_sel = st.selectbox("Subcategoría", list(subcat_dict.keys()), key="prod_edit_subcat")
-            subcat_id = subcat_dict[subcat_sel]
-
-            col1, col2 = st.columns(2)
-            with col1:
-                if st.button("Actualizar producto", key="btn_actualizar_prod"):
-                    cursor.execute("UPDATE productos SET nombre = ?, margen = ?, subcategoria_id = ? WHERE id = ?", (new_nombre.strip(), new_margen, subcat_id, prod_id))
-                    conn.commit()
-                    st.success("Producto actualizado correctamente")
-                    st.experimental_rerun()
-            with col2:
-                if st.button("Eliminar producto", key="btn_eliminar_prod"):
-                    cursor.execute("DELETE FROM productos WHERE id = ?", (prod_id,))
-                    conn.commit()
-                    st.success("Producto eliminado")
-                    st.experimental_rerun()
-
-    st.subheader("Agregar nuevo producto")
-    nuevo_nombre = st.text_input("Nombre del nuevo producto", key="nuevo_prod_nombre")
-    nueva_cat = st.selectbox("Categoría del nuevo producto", categorias_prod["nombre"].tolist(), key="nuevo_prod_cat")
-    nueva_cat_id = categorias_prod[categorias_prod["nombre"] == nueva_cat]["id"].values[0]
-
-    subcats_nuevos = pd.read_sql_query("SELECT * FROM subcategorias_productos WHERE categoria_id = ?", conn, params=(nueva_cat_id,))
-    subcat_dict_nuevos = dict(zip(subcats_nuevos["nombre"], subcats_nuevos["id"]))
-    if subcat_dict_nuevos:
-        subcat_sel_nuevo = st.selectbox("Subcategoría del nuevo producto", list(subcat_dict_nuevos.keys()), key="nuevo_prod_subcat")
-        nueva_subcat_id = subcat_dict_nuevos[subcat_sel_nuevo]
-    else:
-        nueva_subcat_id = None
-
-    nuevo_margen = st.number_input("Margen de ganancia", min_value=1.0, value=3.0, step=0.1, key="nuevo_prod_margen")
-    if st.button("Crear Producto", key="crear_nuevo_prod"):
-        cursor.execute("INSERT INTO productos (nombre, categoria_id, subcategoria_id, margen) VALUES (?, ?, ?, ?)", (nuevo_nombre.strip(), nueva_cat_id, nueva_subcat_id, nuevo_margen))
+# ⚙️ Categorías de Productos (ABM)
+elif seccion == "⚙️ Categorías de Productos (ABM)":
+    st.title("⚙️ Categorías y Subcategorías de Productos")
+    st.subheader("Categorías")
+    categorias_df = pd.read_sql_query("SELECT * FROM categoria_productos", conn)
+    st.dataframe(categorias_df)
+    nueva_cat = st.text_input("Nueva Categoría", key="nueva_cat_prod")
+    if st.button("Agregar Categoría", key="agregar_cat_prod"):
+        cursor.execute("INSERT INTO categoria_productos (nombre) VALUES (?)", (nueva_cat.strip(),))
         conn.commit()
-        st.success("Producto creado correctamente")
         st.experimental_rerun()
+    cat_dict = dict(zip(categorias_df["nombre"], categorias_df["id"]))
+    if cat_dict:
+        cat_sel = st.selectbox("Editar o eliminar categoría", list(cat_dict.keys()), key="cat_edit_prod")
+        cat_id = cat_dict[cat_sel]
+        new_cat_name = st.text_input("Nuevo nombre categoría", value=cat_sel, key="edit_cat_prod_name")
+        col1, col2 = st.columns(2)
+        with col1:
+            if st.button("Actualizar Categoría", key="update_cat_prod"):
+                cursor.execute("UPDATE categoria_productos SET nombre = ? WHERE id = ?", (new_cat_name.strip(), cat_id))
+                conn.commit()
+                st.experimental_rerun()
+        with col2:
+            if st.button("Eliminar Categoría", key="delete_cat_prod"):
+                cursor.execute("DELETE FROM categoria_productos WHERE id = ?", (cat_id,))
+                conn.commit()
+                st.experimental_rerun()
+    st.subheader("Subcategorías")
+    subcats_df = pd.read_sql_query("SELECT sp.id, sp.nombre, cp.nombre AS categoria FROM subcategorias_productos sp JOIN categoria_productos cp ON sp.categoria_id = cp.id", conn)
+    st.dataframe(subcats_df)
+    subcat_nombre = st.text_input("Nueva Subcategoría", key="nueva_subcat_prod")
+    cat_sub_sel = st.selectbox("Categoría para la subcategoría", categorias_df["nombre"].tolist(), key="cat_sub_sel_prod")
+    cat_sub_id = cat_dict[cat_sub_sel]
+    if st.button("Agregar Subcategoría", key="agregar_subcat_prod"):
+        cursor.execute("INSERT INTO subcategorias_productos (nombre, categoria_id) VALUES (?, ?)", (subcat_nombre.strip(), cat_sub_id))
+        conn.commit()
+        st.experimental_rerun()
+
         
 
 


### PR DESCRIPTION
## Summary
- add a new *Categorías de Productos (ABM)* section for managing product categories and subcategories
- remove the duplicated *Producto (ABM)* block

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6845af65dd28832a936c737cb20afc29